### PR TITLE
Issue/8

### DIFF
--- a/h0rton/h0_inference/__init__.py
+++ b/h0rton/h0_inference/__init__.py
@@ -1,1 +1,2 @@
 from .h0_posterior import *
+from .gaussian_bnn_posterior import *

--- a/h0rton/h0_inference/gaussian_bnn_posterior.py
+++ b/h0rton/h0_inference/gaussian_bnn_posterior.py
@@ -1,0 +1,234 @@
+from abc import ABC, abstractmethod
+import random
+import numpy as np
+import torch
+__all__ = ['BaseGaussianBNNPosterior', 'DiagonalGaussianBNNPosterior', 'LowRankGaussianBNNPosterior', 'DoubleGaussianBNNPosterior']
+
+class BaseGaussianBNNPosterior(ABC):
+    """Abstract base class to represent the Gaussian BNN posterior
+
+    Gaussian posteriors or mixtures thereof with various forms of the covariance matrix inherit from this class.
+
+    """
+    def __init__(self, pred, Y_dim, device):
+        """
+        Parameters
+        ----------
+        pred : torch.Tensor of shape `[1, out_dim]` or `[out_dim,]`
+            raw network output for the predictions
+        Y_dim : int
+            number of parameters to predict
+        device : torch.device object
+
+        """
+        self.pred = pred
+        self.batch_size = pred.shape[0]
+        self.Y_dim = Y_dim
+        self.device = device
+        self.sigmoid = torch.nn.Sigmoid()
+        self.logsigmoid = torch.nn.LogSigmoid()
+
+    def _check_input_shape(self, out_dim):
+        """Check if the input tensors have the shapes consistent with the number of parameters to predict
+
+        Parameters
+        ----------
+        out_dim : int
+            dimension of the output expected from `self.Y_dim`
+
+        """
+        if self.pred.shape[1] != out_dim:
+            raise ValueError("Value supplied for `Y_dim` and the shape of `pred` are not consistent.")
+
+    def seed_samples(self, sample_seed):
+        """Seed the sampling for reproducibility
+
+        Parameters
+        ----------
+        sample_seed : int
+
+        """
+        np.random.seed(sample_seed)
+        random.seed(sample_seed)
+        torch.manual_seed(sample_seed)
+        torch.cuda.manual_seed(sample_seed)
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+
+    @abstractmethod
+    def sample(self, n_samples, sample_seed=None):
+        """Sample from the Gaussian posterior. Must be overridden by subclasses.
+
+        Parameters
+        ----------
+        n_samples : int
+            how many samples to obtain
+        sample_seed : int
+            seed for the samples. Default: None
+
+        Returns
+        -------
+        np.array of shape `[n_samples, self.Y_dim]`
+            samples
+
+        """
+        return NotImplemented
+
+    @abstractmethod
+    def get_hpd_interval(self):
+        """Get the highest posterior density (HPD) interval
+
+        """
+        return NotImplemented
+
+    def sample_low_rank(self, n_samples, mu, logvar, F):
+        """Sample from a single Gaussian posterior with a full but low-rank plus diagonal covariance matrix
+
+        Parameters
+        ----------
+        n_samples : int
+            how many samples to obtain
+        mu : torch.Tensor of shape `[self.batch_size, self.Y_dim]`
+            network prediction of the mu (mean parameter) of the BNN posterior
+        logvar : torch.Tensor of shape `[self.batch_size, self.Y_dim]`
+            network prediction of the log of the diagonal elements of the covariance matrix
+        F : torch.Tensor of shape `[self.batch_size, self.Y_dim, self.rank]`
+            network prediction of the low rank portion of the covariance matrix
+
+        Returns
+        -------
+        np.array of shape `[self.batch_size, n_samples, self.Y_dim]`
+            samples
+
+        """
+        #F = torch.unsqueeze(F, dim=1).repeat(1, n_samples, 1, 1) # [self.batch_size, n_samples, self.Y_dim, self.rank]
+        F = F.repeat(n_samples, 1, 1) # [self.batch_size*n_samples, self.Y_dim, self.rank]
+        mu = mu.repeat(n_samples, 1)
+        logvar = logvar.repeat(n_samples, 1)
+        eps_low_rank = torch.randn(self.batch_size*n_samples, self.rank, 1)
+        eps_diag = torch.randn(self.batch_size*n_samples, self.Y_dim)
+        half_var = torch.exp(0.5*logvar) # [self.batch_size*n_samples, self.Y_dim]
+        samples = torch.bmm(F, eps_low_rank).squeeze() + mu + half_var*eps_diag
+        samples = samples.reshape(n_samples, self.batch_size, self.Y_dim)
+        samples = samples.data.cpu().numpy()
+        samples = samples.swapaxes(0, 1)
+        return samples
+
+class DiagonalGaussianBNNPosterior(BaseGaussianBNNPosterior):
+    """The negative log likelihood (NLL) for a single Gaussian with diagonal covariance matrix
+        
+    `BaseGaussianNLL.__init__` docstring for the parameter description.
+
+    """
+    def __init__(self, pred, Y_dim, device):
+        super(DiagonalGaussianBNNPosterior, self).__init__(pred, Y_dim, device)
+        out_dim = self.Y_dim*2
+        self._check_input_shape(out_dim)
+        d = self.Y_dim # for readability
+        self.mu = pred[:, :d].reshape(self.batch_size, -1)
+        self.logvar = pred[:, d:].reshape(self.batch_size, -1)
+
+    def sample(self, n_samples, sample_seed):
+        """Sample from a Gaussian posterior with diagonal covariance matrix
+
+        Parameters
+        ----------
+        n_samples : int
+            how many samples to obtain
+        sample_seed : int
+            seed for the samples. Default: None
+
+        Returns
+        -------
+        np.array of shape `[n_samples, self.Y_dim]`
+            samples
+
+        """
+        self.seed_samples(sample_seed)
+        eps = torch.randn(self.batch_size, n_samples, self.Y_dim)
+        samples = eps*torch.exp(0.5*self.logvar.unsqueeze(1)) + self.mu.unsqueeze(1)
+        samples = samples.data.cpu().numpy()
+        return samples
+
+    def get_hpd_interval(self):
+        return NotImplementedError
+
+class LowRankGaussianBNNPosterior(BaseGaussianBNNPosterior):
+    """The negative log likelihood (NLL) for a single Gaussian with diagonal covariance matrix
+        
+    `BaseGaussianNLL.__init__` docstring for the parameter description.
+
+    """
+    def __init__(self, pred, Y_dim, device):
+        super(LowRankGaussianBNNPosterior, self).__init__(pred, Y_dim, device)
+        out_dim = self.Y_dim*4
+        self._check_input_shape(out_dim)
+        self.rank = 2 # FIXME: hardcoded
+        d = self.Y_dim # for readability
+        self.mu = pred[:, :d].reshape(self.batch_size, -1)
+        self.logvar = pred[:, d:2*d].reshape(self.batch_size, -1)
+        self.F = pred[:, 2*d:].reshape(self.batch_size, self.Y_dim, self.rank)
+
+    def sample(self, n_samples, sample_seed):
+        self.seed_samples(sample_seed)
+        return self.sample_low_rank(n_samples, self.mu, self.logvar, self.F)
+
+    def get_hpd_interval(self):
+        return NotImplementedError
+
+class DoubleGaussianBNNPosterior(BaseGaussianBNNPosterior):
+    """The negative log likelihood (NLL) for a single Gaussian with diagonal covariance matrix
+        
+    `BaseGaussianNLL.__init__` docstring for the parameter description.
+
+    """
+    def __init__(self, pred, Y_dim, device):
+        super(DoubleGaussianBNNPosterior, self).__init__(pred, Y_dim, device)
+        out_dim = self.Y_dim*8 + 1
+        self._check_input_shape(out_dim)
+        self.rank = 2 # FIXME: hardcoded
+        d = self.Y_dim # for readability
+        self.mu = pred[:, :d].reshape(self.batch_size, -1)
+        self.logvar = pred[:, d:2*d].reshape(self.batch_size, -1)
+        self.F = pred[:, 2*d:4*d].reshape(self.batch_size, self.Y_dim, self.rank)
+        self.mu2 = pred[:, 4*d:5*d].reshape(self.batch_size, -1)
+        self.logvar2 = pred[:, 5*d:6*d].reshape(self.batch_size, -1)
+        self.F2 = pred[:, 6*d:8*d].reshape(self.batch_size, self.Y_dim, self.rank)
+        self.w2 = 0.5*self.sigmoid(pred[:, -1].reshape(self.batch_size, -1))
+        
+    def sample(self, n_samples, sample_seed):
+        """Sample from a mixture of two Gaussians, each with a full but constrained as low-rank plus diagonal covariance
+
+        Parameters
+        ----------
+        n_samples : int
+            how many samples to obtain
+        sample_seed : int
+            seed for the samples. Default: None
+
+        Returns
+        -------
+        np.array of shape `[self.batch_size, n_samples, self.Y_dim]`
+            samples
+
+        """
+        self.seed_samples(sample_seed)
+        samples = torch.empty([self.batch_size, n_samples, self.Y_dim], device=self.device)
+        # Determine first vs. second Gaussian
+        unif2 = torch.rand(self.batch_size, n_samples)
+        second_gaussian = (self.w2 > unif2)
+        # Sample from second Gaussian
+        samples2 = torch.Tensor(self.sample_low_rank(n_samples, self.mu2, self.logvar2, self.F2))
+        samples[second_gaussian, :] = samples2[second_gaussian, :]
+        # Sample from first Gaussian
+        samples1 = torch.Tensor(self.sample_low_rank(n_samples, self.mu, self.logvar, self.F))
+        samples[~second_gaussian, :] = samples1[~second_gaussian, :]
+        samples = samples.data.cpu().numpy()
+        return samples
+
+    def get_hpd_interval(self):
+        return NotImplementedError
+
+
+
+

--- a/h0rton/h0_inference/h0_posterior.py
+++ b/h0rton/h0_inference/h0_posterior.py
@@ -10,10 +10,10 @@ from lenstronomy.Analysis.lens_properties import LensProp
 import lenstronomy.Util.param_util as param_util
 import h0rton.tdlmc_utils
 
-__all__ = ['log_gaussian_pdf', 'H0Posterior']
+__all__ = ['gaussian_ll_pdf', 'H0Posterior']
 
-def log_gaussian_pdf(x, mu, sigma):
-    """Evaluates the log of the normal (not lognormal) PDF at point x
+def gaussian_ll_pdf(x, mu, sigma):
+    """Evaluates the log of the normal PDF at point x
     
     Parameters
     ----------
@@ -229,7 +229,7 @@ class H0Posterior:
                 ll_vd = 0.0
             else:
                 inferred_vd = lens_prop.velocity_dispersion(self.kwargs_lens, r_eff=self.lens_light_R_sersic, R_slit=self.R_slit, dR_slit=self.dR_slit, psf_fwhm=self.psf_fwhm, aniso_param=aniso_param, num_evaluate=5000, kappa_ext=k_ext)
-                ll_vd = log_gaussian_pdf(inferred_vd,
+                ll_vd = gaussian_ll_pdf(inferred_vd,
                                        self.measured_vd,
                                        self.measured_vd_err)
             # Time delays
@@ -239,7 +239,7 @@ class H0Posterior:
             else:
                 inferred_td = np.array(inferred_td)
             inferred_td = inferred_td[1:] - inferred_td[0]
-            ll_td = np.sum(log_gaussian_pdf(inferred_td, self.measured_td, self.measured_td_err))
+            ll_td = np.sum(gaussian_ll_pdf(inferred_td, self.measured_td, self.measured_td_err))
             log_w = ll_vd + ll_td
             w = mp.exp(log_w)
 

--- a/h0rton/losses/__init__.py
+++ b/h0rton/losses/__init__.py
@@ -1,1 +1,2 @@
 from .gaussian_nll import DiagonalGaussianNLL, LowRankGaussianNLL, DoubleGaussianNLL
+from .losses_utils import *

--- a/h0rton/losses/__init__.py
+++ b/h0rton/losses/__init__.py
@@ -1,1 +1,1 @@
-from .gaussian_nll import GaussianNLL
+from .gaussian_nll import DiagonalGaussianNLL, LowRankGaussianNLL, DoubleGaussianNLL

--- a/h0rton/losses/gaussian_nll.py
+++ b/h0rton/losses/gaussian_nll.py
@@ -154,7 +154,7 @@ class BaseGaussianNLL(ABC):
         alpha = alpha.reshape(-1)
         log_nll[:, 0] = -torch.log(1.0 - 0.5*sigmoid(alpha)) + self.nll_lowrank(target, mu, logvar, F=F, reduce=False) # [batch_size]
         # torch.log(torch.tensor([0.5], device=self.device)).double()
-        log_nll[:, 1] = 0.6931471 - logsigmoid(alpha) + self.nll_lowrank(target, mu2, logvar2, F=F2, reduce=False) # [batch_size]
+        log_nll[:, 1] = 0.6931471 - logsigmoid(alpha) + self.nll_lowrank(target, mu2, logvar2, F=F2, reduce=False) # [batch_size], 0.6931471 = -np.log(0.5)
         sum_two_gaus = torch.sum(log_nll, dim=1) 
         return torch.mean(sum_two_gaus)
 

--- a/h0rton/losses/gaussian_nll.py
+++ b/h0rton/losses/gaussian_nll.py
@@ -11,12 +11,8 @@ class BaseGaussianNLL(ABC):
         """
         Parameters
         ----------
-        cov_mat : str
-            type of covariance matrix, one of ['diagonal', 'low_rank', 'double']
         Y_dim : int
             number of parameters to predict
-        out_dim : int
-            number of output parameters
         device : torch.device object
 
         """
@@ -51,12 +47,13 @@ class BaseGaussianNLL(ABC):
 
         Returns
         -------
-        torch.Tensor of shape [batch_size,]
+        torch.Tensor of shape
             NLL values
 
         """
         precision = torch.exp(-logvar)
-        return torch.sum(torch.sum(precision * (target - mu)**2.0 + logvar, dim=1), dim=0)
+        print(torch.sum(precision * (target - mu)**2.0 + logvar, dim=1))
+        return torch.mean(torch.sum(precision * (target - mu)**2.0 + logvar, dim=1), dim=0)
 
     def nll_lowrank(self, target, mu, logvar, F, reduce=True):
         """Evaluate the NLL for a single Gaussian with a full but low-rank plus diagonal covariance matrix
@@ -144,7 +141,7 @@ class BaseGaussianNLL(ABC):
             network prediction of the log of the diagonal elements of the covariance matrix for the second Gaussian
         F2 : torch.Tensor of shape [batch_size, rank*Y_dim]
             network prediction of the low rank portion of the covariance matrix for the second Gaussian
-        alpha : torch.Tensor
+        alpha : torch.Tensor of shape [batch_size,]
             network prediction of the logit of twice the weight on the second Gaussian 
         reduce : bool
             whether to take the mean across the batch
@@ -177,7 +174,7 @@ class DiagonalGaussianNLL(BaseGaussianNLL):
 
     """
     def __init__(self, Y_dim, device):
-        super(BaseGaussianNLL, self).__init__(Y_dim, device)
+        super(DiagonalGaussianNLL, self).__init__(Y_dim, device)
         self.out_dim = Y_dim*2
 
     def __call__(self, pred, target):
@@ -193,7 +190,7 @@ class LowRankGaussianNLL(BaseGaussianNLL):
 
     """
     def __init__(self, Y_dim, device):
-        super(BaseGaussianNLL, self).__init__(Y_dim, device)
+        super(LowRankGaussianNLL, self).__init__(Y_dim, device)
         self.out_dim = Y_dim*4
 
     def __call__(self, pred, target):
@@ -209,7 +206,7 @@ class DoubleGaussianNLL(BaseGaussianNLL):
 
     """
     def __init__(self, Y_dim, device):
-        super(BaseGaussianNLL, self).__init__(Y_dim, device)
+        super(DoubleGaussianNLL, self).__init__(Y_dim, device)
         self.out_dim = Y_dim*8 + 1
 
     def __call__(self, pred, target):

--- a/h0rton/losses/gaussian_nll.py
+++ b/h0rton/losses/gaussian_nll.py
@@ -79,31 +79,23 @@ class BaseGaussianNLL(ABC):
         """
         # 1/(Y_dim - 1) * (sq_mahalanobis + log(det of \Sigma))
         batch_size, _ = target.shape # self.Y_dim = Y_dim - 1
-        rank = 2
-        F = F.reshape([batch_size, self.Y_dim, rank]) # FIXME: hardcoded for rank 2
+        rank = 2 # FIXME: hardcoded for rank 2
+        F = F.reshape([batch_size, self.Y_dim, rank]) 
         inv_var = torch.exp(-logvar) # [batch_size, self.Y_dim]
         diag_inv_var = torch.diag_embed(inv_var)  # [batch_size, self.Y_dim, self.Y_dim]
         diag_prod = F**2.0 * inv_var.reshape([batch_size, self.Y_dim, 1]) # [batch_size, self.Y_dim, rank] after broadcasting
         off_diag_prod = torch.prod(F, dim=2)*inv_var # [batch_size, self.Y_dim]
         #batchdiag = torch.diag_embed(torch.exp(logvar)) # [batch_size, self.Y_dim, self.Y_dim]
         #batch_eye = torch.eye(rank).reshape(1, rank, rank).repeat(batch_size, 1, 1) # [batch_size, rank, rank]
-        #assert batchdiag.shape == torch.Size([batch_size, self.Y_dim, self.Y_dim])
-
         # (25), (26) in Miller et al 2016
         log_det = torch.sum(logvar, dim=1) # [batch_size]
         M00 = torch.sum(diag_prod[:, :, 0], dim=1) + 1.0 # [batch_size]
         M11 = torch.sum(diag_prod[:, :, 1], dim=1) + 1.0 # [batch_size]
         M12 = torch.sum(off_diag_prod, dim=1) # [batch_size]
-        assert M00.shape == torch.Size([batch_size])
-        assert M12.shape == torch.Size([batch_size])
         det_M = M00*M11 - M12**2.0 # [batch_size]
-        assert det_M.shape == torch.Size([batch_size])
-        assert log_det.shape == torch.Size([batch_size])
-        log_det += torch.log(det_M) 
-        assert log_det.shape == torch.Size([batch_size])
-        #print(det_M)
+        log_det += torch.log(det_M) # [batch_size,]
 
-        inv_M = torch.ones([batch_size, rank, rank], device=self.device)
+        inv_M = torch.ones([batch_size, rank, rank], device=self.device).double()
         inv_M[:, 0, 0] = M11
         inv_M[:, 1, 1] = M00
         inv_M[:, 1, 0] = -M12
@@ -111,16 +103,13 @@ class BaseGaussianNLL(ABC):
         inv_M /= det_M.reshape(batch_size, 1, 1)
 
         # (27) in Miller et al 2016
-        inv_cov = diag_inv_var - torch.bmm(torch.bmm(torch.bmm(torch.bmm(diag_inv_var, F), inv_M), torch.transpose(F, 1, 2)), diag_inv_var) 
-        assert inv_cov.shape == torch.Size([batch_size, self.Y_dim, self.Y_dim])
-        sq_mahalanobis = torch.bmm(torch.bmm((mu - target).reshape(batch_size, 1, self.Y_dim), inv_cov), (mu - target).reshape(batch_size, self.Y_dim, 1)).reshape(-1)
-        
-        assert sq_mahalanobis.shape == torch.Size([batch_size])
+        inv_cov = diag_inv_var - torch.bmm(torch.bmm(torch.bmm(torch.bmm(diag_inv_var, F), inv_M), torch.transpose(F, 1, 2)), diag_inv_var) # [batch_size, self.Y_dim, self.Y_dim]
+        sq_mahalanobis = torch.bmm(torch.bmm((mu - target).reshape(batch_size, 1, self.Y_dim), inv_cov), (mu - target).reshape(batch_size, self.Y_dim, 1)).reshape(-1) # [batch_size,]
         
         if reduce==True:
-            return torch.sum(sq_mahalanobis + log_det, dim=0)
+            return torch.mean(sq_mahalanobis + log_det, dim=0) # float
         else:
-            return sq_mahalanobis + log_det
+            return sq_mahalanobis + log_det # [batch_size,]
 
     def nll_mixture(self, target, mu, logvar, F, mu2, logvar2, F2, alpha):
         """Evaluate the NLL for a single Gaussian with a full but low-rank plus diagonal covariance matrix
@@ -194,6 +183,7 @@ class LowRankGaussianNLL(BaseGaussianNLL):
         self.out_dim = Y_dim*4
 
     def __call__(self, pred, target):
+        d = self.Y_dim # for readability
         mu = pred[:, :d]
         logvar = pred[:, d:2*d]
         F = pred[:, 2*d:]
@@ -210,6 +200,7 @@ class DoubleGaussianNLL(BaseGaussianNLL):
         self.out_dim = Y_dim*8 + 1
 
     def __call__(self, pred, target):
+        d = self.Y_dim # for readability
         mu = pred[:, :d]
         logvar = pred[:, d:2*d]
         F = pred[:, 2*d:4*d]

--- a/h0rton/losses/losses_utils.py
+++ b/h0rton/losses/losses_utils.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+__all__ = ['sigmoid']
+
+def sigmoid(x):
+    """Evaluate the sigmoid function 
+
+    Note
+    ----
+    Numerically stable version pending.
+
+    x : float or array-like
+        value to evaluate on
+
+    """
+    return 1.0/(1.0 + np.exp(-x))

--- a/h0rton/tests/__init__.py
+++ b/h0rton/tests/__init__.py
@@ -1,0 +1,2 @@
+import logging
+logging.disable(logging.CRITICAL)

--- a/h0rton/tests/test_h0_inference/test_gaussian_bnn_posterior.py
+++ b/h0rton/tests/test_h0_inference/test_gaussian_bnn_posterior.py
@@ -1,0 +1,116 @@
+import os, sys
+import unittest
+import numpy as np
+import torch
+
+class TestGaussianBNNPosterior(unittest.TestCase):
+    """A suite of tests verifying that the input PDFs and the sample distributions
+    match.
+    
+    """
+    def test_diagonal_gaussian_bnn_posterior(self):
+        """Test the sampling of `DiagonalGaussianBNNPosterior`
+
+        """
+        from h0rton.h0_inference import DiagonalGaussianBNNPosterior
+        from scipy.stats import multivariate_normal
+        Y_dim = 2
+        batch_size = 3
+        rank = 2
+        sample_seed = 1113
+        device = torch.device('cpu')
+        mu = np.random.randn(batch_size, Y_dim)
+        logvar = np.abs(np.random.randn(batch_size, Y_dim))
+        pred = np.concatenate([mu, logvar], axis=1)
+        # Get h0rton samples
+        diagonal_bnn_post = DiagonalGaussianBNNPosterior(torch.Tensor(pred), Y_dim, device)
+        h0rton_samples = diagonal_bnn_post.sample(10**6, sample_seed)
+        # Get h0rton summary stats
+        h0rton_mean = np.mean(h0rton_samples, axis=1)
+        h0rton_covmat = np.zeros((batch_size, Y_dim, Y_dim))
+        exp_covmat = np.zeros((batch_size, Y_dim, Y_dim))
+        for b in range(batch_size):
+            cov_b = np.cov(h0rton_samples[b, :, :].swapaxes(0, 1), ddof=0)
+            h0rton_covmat[b, :, :] = cov_b
+            exp_covmat[b, :, :] += np.diagflat(np.exp(logvar[b, :]))
+        # Get expected summary stats
+        exp_mean = mu
+        np.testing.assert_array_almost_equal(h0rton_mean, exp_mean, decimal=2)
+        np.testing.assert_array_almost_equal(h0rton_covmat, exp_covmat, decimal=2)
+
+    def test_low_rank_gaussian_bnn_posterior(self):
+        """Test the sampling of `LowRankGaussianBNNPosterior`
+
+        """
+        from h0rton.h0_inference import LowRankGaussianBNNPosterior
+        from scipy.stats import multivariate_normal
+        Y_dim = 2
+        batch_size = 3
+        rank = 2
+        sample_seed = 1113
+        device = torch.device('cpu')
+        mu = np.random.randn(batch_size, Y_dim)
+        logvar = np.abs(np.random.randn(batch_size, Y_dim))
+        F = np.random.randn(batch_size, Y_dim*rank)
+        F_unraveled = F.reshape(batch_size, Y_dim, rank)
+        FFT = np.matmul(F_unraveled, np.swapaxes(F_unraveled, 1, 2))
+        pred = np.concatenate([mu, logvar, F], axis=1)
+        # Get h0rton samples
+        low_rank_bnn_post = LowRankGaussianBNNPosterior(torch.Tensor(pred), Y_dim, device)
+        h0rton_samples = low_rank_bnn_post.sample(10**7, sample_seed)
+        # Get h0rton summary stats
+        h0rton_mean = np.mean(h0rton_samples, axis=1)
+        h0rton_covmat = np.empty((batch_size, Y_dim, Y_dim))
+        exp_covmat = FFT
+        for b in range(batch_size):
+            cov_b = np.cov(h0rton_samples[b, :, :].swapaxes(0, 1), ddof=0)
+            h0rton_covmat[b, :, :] = cov_b
+            exp_covmat[b, :, :] += np.diagflat(np.exp(logvar[b, :]))
+        # Get expected summary stats
+        exp_mean = mu
+        np.testing.assert_array_almost_equal(h0rton_mean, exp_mean, decimal=2)
+        np.testing.assert_array_almost_equal(h0rton_covmat, exp_covmat, decimal=2)
+
+    def test_double_gaussian_bnn_posterior(self):
+        """Test the sampling of `DoubleGaussianBNNPosterior`
+    
+        Note
+        ----
+        Only compares the true and sample means
+
+        """
+        from h0rton.h0_inference import DoubleGaussianBNNPosterior
+        from h0rton.losses import sigmoid
+        from scipy.stats import multivariate_normal
+        Y_dim = 2
+        batch_size = 3
+        rank = 2
+        sample_seed = 1113
+        device = torch.device('cpu')
+        # First gaussian
+        mu = np.random.randn(batch_size, Y_dim)
+        logvar = np.abs(np.random.randn(batch_size, Y_dim))
+        F = np.random.randn(batch_size, Y_dim*rank)
+        F_unraveled = F.reshape(batch_size, Y_dim, rank)
+        FFT = np.matmul(F_unraveled, np.swapaxes(F_unraveled, 1, 2))
+        # Second gaussian
+        mu2 = np.random.randn(batch_size, Y_dim)
+        logvar2 = np.abs(np.random.randn(batch_size, Y_dim))
+        F2 = np.random.randn(batch_size, Y_dim*rank)
+        F2_unraveled = F2.reshape(batch_size, Y_dim, rank)
+        FFT2 = np.matmul(F2_unraveled, np.swapaxes(F2_unraveled, 1, 2))
+        alpha = np.random.randn(batch_size, 1)
+        pred = np.concatenate([mu, logvar, F, mu2, logvar2, F2, alpha], axis=1)
+        # Get h0rton samples
+        double_bnn_post = DoubleGaussianBNNPosterior(torch.Tensor(pred), Y_dim, device)
+        h0rton_samples = double_bnn_post.sample(10**7, sample_seed)
+        # Get h0rton summary stats
+        h0rton_mean = np.mean(h0rton_samples, axis=1)
+        # Get expected summary stats
+        w2 = 0.5*sigmoid(alpha)
+        w1 = 1.0 - w2
+        exp_mean = mu*w1 + mu2*w2
+        np.testing.assert_array_almost_equal(h0rton_mean, exp_mean, decimal=2)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/h0rton/tests/test_h0_inference/test_h0_posterior.py
+++ b/h0rton/tests/test_h0_inference/test_h0_posterior.py
@@ -5,19 +5,20 @@ import unittest
 class TestH0Posterior(unittest.TestCase):
     """A suite of tests verifying that the input PDFs and the sample distributions
     match.
+    
     """
 
-    def test_generalized_normal(self):
+    def test_gaussian_ll_pdf(self):
         """Test the log normal PDF
 
         """
-        from h0rton.h0_inference import log_normal_pdf
+        from h0rton.h0_inference import gaussian_ll_pdf
         from scipy.stats import norm
         m = 0.5
         s = 1
         eval_x = np.linspace(-3, 3, 100)
         truth = np.log(norm.pdf(eval_x, m, s))
-        pred = log_normal_pdf(eval_x, m, s)
+        pred = gaussian_ll_pdf(eval_x, m, s)
         np.testing.assert_array_almost_equal(pred, truth)
 
 if __name__ == '__main__':

--- a/h0rton/tests/test_losses/test_gaussian_nll.py
+++ b/h0rton/tests/test_losses/test_gaussian_nll.py
@@ -31,7 +31,9 @@ class TestGaussianNLL(unittest.TestCase):
             mu_b = mu[b, :]
             cov_b = np.diagflat(np.exp(logvar[b, :]))
             nll = -np.log(multivariate_normal.pdf(target_b, mean=mu_b, cov=cov_b)) # real nll, not scaled and shifted
-            matched_nll += (2.0*nll - Y_dim*np.log(2.0*np.pi))/batch_size
+            matched_nll += nll/batch_size
+            print(nll)
+            #matched_nll += (2.0*nll - Y_dim*np.log(2.0*np.pi))/batch_size # kernel version
         np.testing.assert_array_almost_equal(h0rton_nll, matched_nll, decimal=6)
 
     def test_low_rank_gaussian_nll(self):
@@ -62,7 +64,8 @@ class TestGaussianNLL(unittest.TestCase):
             F_b = F[b, :].reshape(Y_dim, rank)
             low_rank_b =  np.matmul(F_b, F_b.T)
             nll = -np.log(multivariate_normal.pdf(target_b, mean=mu_b, cov=diag_b + low_rank_b)) # real nll, not scaled and shifted
-            matched_nll += (2.0*nll - Y_dim*np.log(2.0*np.pi))/batch_size
+            matched_nll += nll/batch_size
+            #matched_nll += (2.0*nll - Y_dim*np.log(2.0*np.pi))/batch_size
         np.testing.assert_array_almost_equal(h0rton_nll, matched_nll, decimal=6)
 
     def test_double_gaussian_nll(self):
@@ -108,12 +111,10 @@ class TestGaussianNLL(unittest.TestCase):
 
             nll1 = -np.log(multivariate_normal.pdf(target_b, mean=mu_b, cov=diag_b + low_rank_b)) # real likelihood, not scaled and shifted
             nll2 = -np.log(multivariate_normal.pdf(target_b, mean=mu2_b, cov=diag2_b + low_rank2_b)) # real likelihood, not scaled and shifted
-            matched_nll1 = (2.0*nll1 - Y_dim*np.log(2.0*np.pi))
-            matched_nll2 = (2.0*nll2 - Y_dim*np.log(2.0*np.pi))
-            matched_nll += (-np.log((1.0 - w2_b) * np.exp(-matched_nll1) + w2_b * np.exp(-matched_nll2)))/batch_size
-            #print(matched_nll1 + matched_nll2)
-            #nll = -np.log((1.0 - w2_b)) + nll1 - np.log(w2_b) + nll2 
-            #matched_nll += (2.0*nll - Y_dim*np.log(2.0*np.pi))/batch_size
+            #matched_nll1 = (2.0*nll1 - Y_dim*np.log(2.0*np.pi))
+            #matched_nll2 = (2.0*nll2 - Y_dim*np.log(2.0*np.pi))
+            #matched_nll += (-np.log((1.0 - w2_b) * np.exp(-matched_nll1) + w2_b * np.exp(-matched_nll2)))/batch_size
+            matched_nll += (-np.log((1.0 - w2_b) * np.exp(-nll1) + w2_b * np.exp(-nll2)))/batch_size # logsumexp
         np.testing.assert_array_almost_equal(h0rton_nll, matched_nll, decimal=6)
 
         

--- a/h0rton/tests/test_losses/test_gaussian_nll.py
+++ b/h0rton/tests/test_losses/test_gaussian_nll.py
@@ -1,0 +1,67 @@
+import os, sys
+import numpy as np
+import unittest
+import torch
+
+class TestGaussianNLL(unittest.TestCase):
+    """A suite of tests verifying the PDF evaluation of GaussianNLL
+    
+    """
+    def test_diagonal_gaussian_ll_pdf(self):
+        """Test the PDF evaluation of a single Gaussian with diagonal covariance matrix
+
+        """
+        from h0rton.losses import DiagonalGaussianNLL
+        from scipy.stats import multivariate_normal
+        # Instantiate NLL class
+        Y_dim = 2
+        device = torch.device('cpu')
+        diagonal_gaussian_nll = DiagonalGaussianNLL(Y_dim, device)
+        # Get h0rton evaluation
+        batch_size = 3
+        target = np.random.randn(batch_size, Y_dim)
+        mu = np.random.randn(batch_size, Y_dim)
+        logvar = np.abs(2.0*np.random.randn(batch_size, Y_dim))
+        pred = np.concatenate([mu, logvar], axis=1)
+        h0rton_nll = diagonal_gaussian_nll(torch.from_numpy(pred), torch.from_numpy(target))
+        # Get scipy evaluation
+        matched_nll = 0.0
+        for b in range(batch_size):
+            target_b = target[b, :]
+            mu_b = mu[b, :]
+            cov_b = np.diagflat(np.exp(logvar[b, :]))
+            nll = -np.log(multivariate_normal.pdf(target_b, mean=mu_b, cov=cov_b)) # real nll, not scaled and shifted
+            matched_nll += (2.0*nll - Y_dim*np.log(2.0*np.pi))/batch_size
+        np.testing.assert_array_almost_equal(h0rton_nll, matched_nll, decimal=6)
+
+    def test_lowrank_gaussian_ll_pdf(self):
+        """Test the PDF evaluation of a single Gaussian with a full but low-rank plus diagonal covariance matrix
+
+        """
+        from h0rton.losses import LowRankGaussianNLL
+        from scipy.stats import multivariate_normal
+        # Instantiate NLL class
+        Y_dim = 2
+        rank = 2
+        device = torch.device('cpu')
+        diagonal_gaussian_nll = LowRankGaussianNLL(Y_dim, device)
+        # Get h0rton evaluation
+        batch_size = 3
+        target = np.random.randn(batch_size, Y_dim)
+        mu = np.random.randn(batch_size, Y_dim)
+        logvar = np.abs(2.0*np.random.randn(batch_size, Y_dim))
+        F = np.random.randn(batch_size, rank*Y_dim)
+        pred = np.concatenate([mu, logvar, F], axis=1)
+        h0rton_nll = diagonal_gaussian_nll(torch.from_numpy(pred), torch.from_numpy(target))
+        # Get scipy evaluation
+        matched_nll = 0.0
+        for b in range(batch_size):
+            target_b = target[b, :]
+            mu_b = mu[b, :]
+            cov_b = np.diagflat(np.exp(logvar[b, :]))
+            nll = -np.log(multivariate_normal.pdf(target_b, mean=mu_b, cov=cov_b)) # real nll, not scaled and shifted
+            matched_nll += (2.0*nll - Y_dim*np.log(2.0*np.pi))/batch_size
+        np.testing.assert_array_almost_equal(h0rton_nll, matched_nll, decimal=6)
+
+        
+

--- a/h0rton/tests/test_losses/test_gaussian_nll.py
+++ b/h0rton/tests/test_losses/test_gaussian_nll.py
@@ -110,7 +110,7 @@ class TestGaussianNLL(unittest.TestCase):
             nll2 = -np.log(multivariate_normal.pdf(target_b, mean=mu2_b, cov=diag2_b + low_rank2_b)) # real likelihood, not scaled and shifted
             matched_nll1 = (2.0*nll1 - Y_dim*np.log(2.0*np.pi))
             matched_nll2 = (2.0*nll2 - Y_dim*np.log(2.0*np.pi))
-            matched_nll += (-np.log(1.0 - w2_b) + matched_nll1 - np.log(w2_b) + matched_nll2)/batch_size
+            matched_nll += (-np.log((1.0 - w2_b) * np.exp(-matched_nll1) + w2_b * np.exp(-matched_nll2)))/batch_size
             #print(matched_nll1 + matched_nll2)
             #nll = -np.log((1.0 - w2_b)) + nll1 - np.log(w2_b) + nll2 
             #matched_nll += (2.0*nll - Y_dim*np.log(2.0*np.pi))/batch_size

--- a/h0rton/tests/test_losses/test_gaussian_nll.py
+++ b/h0rton/tests/test_losses/test_gaussian_nll.py
@@ -65,7 +65,7 @@ class TestGaussianNLL(unittest.TestCase):
             low_rank_b =  np.matmul(F_b, F_b.T)
             nll = -np.log(multivariate_normal.pdf(target_b, mean=mu_b, cov=diag_b + low_rank_b)) # real nll, not scaled and shifted
             matched_nll += nll/batch_size
-            #matched_nll += (2.0*nll - Y_dim*np.log(2.0*np.pi))/batch_size
+            #matched_nll += (2.0*nll - Y_dim*np.log(2.0*np.pi))/batch_size # kernel version
         np.testing.assert_array_almost_equal(h0rton_nll, matched_nll, decimal=6)
 
     def test_double_gaussian_nll(self):
@@ -111,9 +111,10 @@ class TestGaussianNLL(unittest.TestCase):
 
             nll1 = -np.log(multivariate_normal.pdf(target_b, mean=mu_b, cov=diag_b + low_rank_b)) # real likelihood, not scaled and shifted
             nll2 = -np.log(multivariate_normal.pdf(target_b, mean=mu2_b, cov=diag2_b + low_rank2_b)) # real likelihood, not scaled and shifted
+            # Kernel version
             #matched_nll1 = (2.0*nll1 - Y_dim*np.log(2.0*np.pi))
             #matched_nll2 = (2.0*nll2 - Y_dim*np.log(2.0*np.pi))
-            #matched_nll += (-np.log((1.0 - w2_b) * np.exp(-matched_nll1) + w2_b * np.exp(-matched_nll2)))/batch_size
+            #matched_nll += (-np.log((1.0 - w2_b) * np.exp(-matched_nll1) + w2_b * np.exp(-matched_nll2)))/batch_size 
             matched_nll += (-np.log((1.0 - w2_b) * np.exp(-nll1) + w2_b * np.exp(-nll2)))/batch_size # logsumexp
         np.testing.assert_array_almost_equal(h0rton_nll, matched_nll, decimal=6)
 

--- a/h0rton/tests/test_losses/test_gaussian_nll.py
+++ b/h0rton/tests/test_losses/test_gaussian_nll.py
@@ -49,7 +49,7 @@ class TestGaussianNLL(unittest.TestCase):
         batch_size = 3
         target = np.random.randn(batch_size, Y_dim)
         mu = np.random.randn(batch_size, Y_dim)
-        logvar = np.abs(2.0*np.random.randn(batch_size, Y_dim))
+        logvar = np.abs(np.random.randn(batch_size, Y_dim))
         F = np.random.randn(batch_size, rank*Y_dim)
         pred = np.concatenate([mu, logvar, F], axis=1)
         h0rton_nll = low_rank_gaussian_nll(torch.from_numpy(pred), torch.from_numpy(target))
@@ -69,7 +69,7 @@ class TestGaussianNLL(unittest.TestCase):
         """Test the PDF evaluation of a mixture of two Gaussians, each with a full but low-rank plus diagonal covariance matrix
 
         """
-        from h0rton.losses import DoubleGaussianNLL
+        from h0rton.losses import DoubleGaussianNLL, sigmoid
         from scipy.stats import multivariate_normal
         # Instantiate NLL class
         Y_dim = 2
@@ -80,20 +80,40 @@ class TestGaussianNLL(unittest.TestCase):
         batch_size = 3
         target = np.random.randn(batch_size, Y_dim)
         mu = np.random.randn(batch_size, Y_dim)
-        logvar = np.abs(2.0*np.random.randn(batch_size, Y_dim))
+        logvar = np.abs(np.random.randn(batch_size, Y_dim))
         F = np.random.randn(batch_size, rank*Y_dim)
-        pred = np.concatenate([mu, logvar, F], axis=1)
+        mu2 = np.random.randn(batch_size, Y_dim)
+        logvar2 = np.abs(np.random.randn(batch_size, Y_dim))
+        F2 = np.random.randn(batch_size, rank*Y_dim)
+        alpha = np.random.randn(batch_size, 1)
+
+        pred = np.concatenate([mu, logvar, F, mu2, logvar2, F2, alpha], axis=1)
         h0rton_nll = double_gaussian_nll(torch.from_numpy(pred), torch.from_numpy(target))
         # Get scipy evaluation
         matched_nll = 0.0
         for b in range(batch_size):
             target_b = target[b, :]
+            # First gaussian
             mu_b = mu[b, :]
             diag_b = np.diagflat(np.exp(logvar[b, :]))
             F_b = F[b, :].reshape(Y_dim, rank)
             low_rank_b =  np.matmul(F_b, F_b.T)
-            nll = -np.log(multivariate_normal.pdf(target_b, mean=mu_b, cov=diag_b + low_rank_b)) # real nll, not scaled and shifted
-            matched_nll += (2.0*nll - Y_dim*np.log(2.0*np.pi))/batch_size
+            # Second gaussian
+            mu2_b = mu2[b, :]
+            diag2_b = np.diagflat(np.exp(logvar2[b, :]))
+            F2_b = F2[b, :].reshape(Y_dim, rank)
+            low_rank2_b =  np.matmul(F2_b, F2_b.T)
+            # Relative weight
+            w2_b = 0.5*sigmoid(alpha[b])
+
+            nll1 = -np.log(multivariate_normal.pdf(target_b, mean=mu_b, cov=diag_b + low_rank_b)) # real likelihood, not scaled and shifted
+            nll2 = -np.log(multivariate_normal.pdf(target_b, mean=mu2_b, cov=diag2_b + low_rank2_b)) # real likelihood, not scaled and shifted
+            matched_nll1 = (2.0*nll1 - Y_dim*np.log(2.0*np.pi))
+            matched_nll2 = (2.0*nll2 - Y_dim*np.log(2.0*np.pi))
+            matched_nll += (-np.log(1.0 - w2_b) + matched_nll1 - np.log(w2_b) + matched_nll2)/batch_size
+            #print(matched_nll1 + matched_nll2)
+            #nll = -np.log((1.0 - w2_b)) + nll1 - np.log(w2_b) + nll2 
+            #matched_nll += (2.0*nll - Y_dim*np.log(2.0*np.pi))/batch_size
         np.testing.assert_array_almost_equal(h0rton_nll, matched_nll, decimal=6)
 
         


### PR DESCRIPTION
**What this PR adds**
This PR is for merging #8, which implements and tests three BNN posterior classes `DiagonalGaussianBNNPosterior`, `LowRankGaussianBNNPosterior` and `DoubleGaussianBNNPosterior` inheriting from the abstract base class `BaseGaussianBNNPosterior`. The names are long because we expect to add non-Gaussian forms of the posterior, e.g. multidimensional gamma, in the future.

**Design**
An instantiation of each BNN posterior class represents a batch of BNN posteriors. It comes with a sampling method, `self.sample(n_samples, sampling_seed)`. We want to be able to sample from the BNN posteriors of many lenses at a time, and the batch sampling parallelizes across multiple lenses. 

I've also left placeholders for the highest posterior density interval evaluation, `self.get_hpd_interval()`, which I'll tackle in a different issue. The evaluation is analytical for a single Gaussian but numerical for multiple Gaussians.